### PR TITLE
migrate ChartsRealmDemo and bugfix

### DIFF
--- a/ChartsRealmDemo/ChartsRealmDemo.xcodeproj/project.pbxproj
+++ b/ChartsRealmDemo/ChartsRealmDemo.xcodeproj/project.pbxproj
@@ -408,7 +408,7 @@
 				TargetAttributes = {
 					5B57BBAE1A9B26AA0036A6CC = {
 						CreatedOnToolsVersion = 6.1.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 				};
 			};
@@ -657,7 +657,8 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Supporting Files/ChartsRealmDemo-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -676,7 +677,8 @@
 				PRODUCT_NAME = ChartsRealmDemo;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Supporting Files/ChartsRealmDemo-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/ChartsRealmDemo/Classes/Components/BalloonMarker.swift
+++ b/ChartsRealmDemo/Classes/Components/BalloonMarker.swift
@@ -25,7 +25,7 @@ open class BalloonMarker: MarkerImage
     fileprivate var labelns: NSString?
     fileprivate var _labelSize: CGSize = CGSize()
     fileprivate var _paragraphStyle: NSMutableParagraphStyle?
-    fileprivate var _drawAttributes = [String : AnyObject]()
+    fileprivate var _drawAttributes = [NSAttributedStringKey : AnyObject]()
     
     public init(color: UIColor, font: UIFont, textColor: UIColor, insets: UIEdgeInsets)
     {
@@ -122,11 +122,11 @@ open class BalloonMarker: MarkerImage
         labelns = label as NSString
         
         _drawAttributes.removeAll()
-        _drawAttributes[NSFontAttributeName] = self.font
-        _drawAttributes[NSParagraphStyleAttributeName] = _paragraphStyle
-        _drawAttributes[NSForegroundColorAttributeName] = self.textColor
+        _drawAttributes[NSAttributedStringKey.font] = self.font
+        _drawAttributes[NSAttributedStringKey.paragraphStyle] = _paragraphStyle
+        _drawAttributes[NSAttributedStringKey.foregroundColor] = self.textColor
         
-        _labelSize = labelns?.size(attributes: _drawAttributes) ?? CGSize.zero
+        _labelSize = labelns?.size(withAttributes: _drawAttributes) ?? CGSize.zero
         
         var size = CGSize()
         size.width = _labelSize.width + self.insets.left + self.insets.right

--- a/ChartsRealmDemo/Classes/RealmDemos/RealmBarChartViewController.m
+++ b/ChartsRealmDemo/Classes/RealmDemos/RealmBarChartViewController.m
@@ -70,10 +70,10 @@
 
     BarChartData *data = [[BarChartData alloc] initWithDataSets:dataSets];
     [self styleData:data];
-    
-    [_chartView zoomWithScaleX:5.f scaleY:1.f x:0.f y:0.f];
+
     _chartView.fitBars = YES;
     _chartView.data = data;
+    [_chartView zoomWithScaleX:5.f scaleY:1.f x:0.f y:0.f];
     
     [_chartView animateWithYAxisDuration:1.4 easingOption:ChartEasingOptionEaseInOutQuart];
 }

--- a/ChartsRealmDemo/Classes/RealmDemos/RealmCandleChartViewController.m
+++ b/ChartsRealmDemo/Classes/RealmDemos/RealmCandleChartViewController.m
@@ -81,9 +81,9 @@
     
     CandleChartData *data = [[CandleChartData alloc] initWithDataSets:dataSets];
     [self styleData:data];
-    
-    [_chartView zoomWithScaleX:5.f scaleY:1.f x:0.f y:0.f];
+
     _chartView.data = data;
+    [_chartView zoomWithScaleX:5.f scaleY:1.f x:0.f y:0.f];
     
     [_chartView animateWithYAxisDuration:1.4 easingOption:ChartEasingOptionEaseInOutQuart];
 }

--- a/ChartsRealmDemo/Classes/RealmDemos/RealmLineChartViewController.m
+++ b/ChartsRealmDemo/Classes/RealmDemos/RealmLineChartViewController.m
@@ -86,9 +86,9 @@
     
     LineChartData *data = [[LineChartData alloc] initWithDataSets:dataSets];
     [self styleData:data];
-    
-    [_chartView zoomWithScaleX:5.f scaleY:1.f x:0.f y:0.f];
+
     _chartView.data = data;
+    [_chartView zoomWithScaleX:5.f scaleY:1.f x:0.f y:0.f];
     
     [_chartView animateWithYAxisDuration:1.4 easingOption:ChartEasingOptionEaseInOutQuart];
 }

--- a/ChartsRealmDemo/Classes/RealmDemos/RealmScatterChartViewController.m
+++ b/ChartsRealmDemo/Classes/RealmDemos/RealmScatterChartViewController.m
@@ -76,9 +76,9 @@
     
     ScatterChartData *data = [[ScatterChartData alloc] initWithDataSets:dataSets];
     [self styleData:data];
-    
-    [_chartView zoomWithScaleX:5.f scaleY:1.f x:0.f y:0.f];
+
     _chartView.data = data;
+    [_chartView zoomWithScaleX:5.f scaleY:1.f x:0.f y:0.f];
     
     [_chartView animateWithYAxisDuration:1.4 easingOption:ChartEasingOptionEaseInOutQuart];
 }


### PR DESCRIPTION
1. upgrade ChartsRealmDemo to swift 4
2. fix `CGAffineTransformInvert: singular matrix` warning. data setter and zoom() order is reversed