### PR TITLE
Add a missing designated initializer inheritance for RealmBarDataSet

### DIFF
--- a/ChartsRealm/Classes/Data/RealmBarDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmBarDataSet.swift
@@ -27,6 +27,11 @@ open class RealmBarDataSet: RealmBarLineScatterCandleBubbleDataSet, IBarChartDat
     {
         super.init()
     }
+
+    public override init(label: String?)
+    {
+        super.init(label: label)
+    }
     
     public override init(results: RLMResults<RLMObject>?, xValueField: String?, yValueField: String, label: String?)
     {


### PR DESCRIPTION
Add a missing designated initializer inheritance for RealmBarDataSet

Now we can inherit all superclass convenience initializer, especially
```swift
public convenience init(results: Results<Object>?, xValueField: String?, yValueField: String)
```