### PR TITLE
update carthage and pod info to 3.0.5

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "danielgindi/Charts" "master"
-github "realm/realm-cocoa" "master"
+github "realm/realm-cocoa" ~> 3.1.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "danielgindi/Charts" "9706fa140bbce03e0e4fb7f798a3b2a13e8f0eb4"
-github "realm/realm-cocoa" "95d69bebbeebf30a5bf00f8923638ed16e3899ce"
+github "danielgindi/Charts" "b1191bc146b98fddb0cab7324f94a993ffa3d74f"
+github "realm/realm-cocoa" "v3.1.1"

--- a/ChartsRealm.podspec
+++ b/ChartsRealm.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ChartsRealm"
-  s.version = "3.0.4"
+  s.version = "3.0.5"
   s.summary = "A Realm.io module for Charts"
   s.homepage = "https://github.com/danielgindi/ChartsRealm"
   s.license = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.11"
   s.source = { :git => "https://github.com/danielgindi/ChartsRealm.git", :tag => "v#{s.version}" }
   s.source_files  = "ChartsRealm/Classes/**/*.swift"
-  s.dependency "Charts", "3.0.4"
-  s.dependency "RealmSwift", "~> 2.10"
+  s.dependency "Charts", "3.0.5"
+  s.dependency "RealmSwift", "~> 3.1.1"
 end


### PR DESCRIPTION
update carthage and pod info to 3.0.5
keep Charts refer to master so far.
Will change to 3.1.0 for Charts later