### PR TITLE
Xcode 10.2 / Swift 4.2 Fixes

### DIFF
--- a/ChartsRealm/Classes/Data/RealmBarDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmBarDataSet.swift
@@ -317,10 +317,8 @@ open class RealmBarDataSet: RealmBarLineScatterCandleBubbleDataSet, IBarChartDat
     open var highlightAlpha = CGFloat(120.0 / 255.0)
     
     // MARK: - NSCopying
-    
-    open override func copyWithZone(_ zone: NSZone?) -> AnyObject
-    {
-        let copy = super.copyWithZone(zone) as! RealmBarDataSet
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = super.copy(with: zone) as! RealmBarDataSet
         copy._stackSize = _stackSize
         copy.stackLabels = stackLabels
         copy.barShadowColor = barShadowColor

--- a/ChartsRealm/Classes/Data/RealmBarLineScatterCandleBubbleDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmBarLineScatterCandleBubbleDataSet.swift
@@ -27,9 +27,8 @@ open class RealmBarLineScatterCandleBubbleDataSet: RealmBaseDataSet, IBarLineSca
     
     // MARK: - NSCopying
     
-    open override func copyWithZone(_ zone: NSZone?) -> AnyObject
-    {
-        let copy = super.copyWithZone(zone) as! RealmBarLineScatterCandleBubbleDataSet
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = super.copy(with: zone) as! RealmBarLineScatterCandleBubbleDataSet
         copy.highlightColor = highlightColor
         copy.highlightLineWidth = highlightLineWidth
         copy.highlightLineDashPhase = highlightLineDashPhase

--- a/ChartsRealm/Classes/Data/RealmBaseDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmBaseDataSet.swift
@@ -625,10 +625,8 @@ open class RealmBaseDataSet: ChartBaseDataSet
     
     // MARK: - NSCopying
     
-    open override func copyWithZone(_ zone: NSZone?) -> AnyObject
-    {
-        let copy = super.copyWithZone(zone) as! RealmBaseDataSet
-        
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = super.copy(with: zone) as! RealmBaseDataSet
         copy._results = _results
         copy._yValueField = _yValueField
         copy._xValueField = _xValueField

--- a/ChartsRealm/Classes/Data/RealmBubbleDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmBubbleDataSet.swift
@@ -130,10 +130,8 @@ open class RealmBubbleDataSet: RealmBarLineScatterCandleBubbleDataSet, IBubbleCh
     open var highlightCircleWidth: CGFloat = 2.5
     
     // MARK: - NSCopying
-    
-    open override func copyWithZone(_ zone: NSZone?) -> AnyObject
-    {
-        let copy = super.copyWithZone(zone) as! RealmBubbleDataSet
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = super.copy(with: zone) as! RealmBubbleDataSet
         copy._xMin = _xMin
         copy._xMax = _xMax
         copy._maxSize = _maxSize

--- a/ChartsRealm/Classes/Data/RealmLineDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmLineDataSet.swift
@@ -172,10 +172,8 @@ open class RealmLineDataSet: RealmLineRadarDataSet, ILineChartDataSet
     }
     
     // MARK: NSCopying
-    
-    open override func copyWithZone(_ zone: NSZone?) -> AnyObject
-    {
-        let copy = super.copyWithZone(zone) as! RealmLineDataSet
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = super.copy(with: zone) as! RealmLineDataSet
         copy.circleRadius = circleRadius
         copy.circleHoleRadius = circleHoleRadius
         copy.circleColors = circleColors

--- a/ChartsRealm/Classes/Data/RealmLineRadarDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmLineRadarDataSet.swift
@@ -79,10 +79,8 @@ open class RealmLineRadarDataSet: RealmLineScatterCandleRadarDataSet, ILineRadar
     }
     
     // MARK: NSCopying
-    
-    open override func copyWithZone(_ zone: NSZone?) -> AnyObject
-    {
-        let copy = super.copyWithZone(zone) as! RealmLineRadarDataSet
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = super.copy(with: zone) as! RealmLineRadarDataSet
         copy.fillColor = fillColor
         copy._lineWidth = _lineWidth
         copy.drawFilledEnabled = drawFilledEnabled

--- a/ChartsRealm/Classes/Data/RealmLineScatterCandleRadarDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmLineScatterCandleRadarDataSet.swift
@@ -41,10 +41,8 @@ open class RealmLineScatterCandleRadarDataSet: RealmBarLineScatterCandleBubbleDa
     }
     
     // MARK: NSCopying
-    
-    open override func copyWithZone(_ zone: NSZone?) -> AnyObject
-    {
-        let copy = super.copyWithZone(zone) as! RealmLineScatterCandleRadarDataSet
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = super.copy(with: zone) as! RealmLineScatterCandleRadarDataSet
         copy.drawHorizontalHighlightIndicatorEnabled = drawHorizontalHighlightIndicatorEnabled
         copy.drawVerticalHighlightIndicatorEnabled = drawVerticalHighlightIndicatorEnabled
         return copy

--- a/ChartsRealm/Classes/Data/RealmPieDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmPieDataSet.swift
@@ -132,9 +132,8 @@ open class RealmPieDataSet: RealmBaseDataSet, IPieChartDataSet
     
     // MARK: - NSCopying
     
-    open override func copyWithZone(_ zone: NSZone?) -> AnyObject
-    {
-        let copy = super.copyWithZone(zone) as! RealmPieDataSet
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = super.copy(with: zone) as! RealmPieDataSet
         copy._sliceSpace = _sliceSpace
         copy.selectionShift = selectionShift
         return copy

--- a/ChartsRealm/Classes/Data/RealmPieDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmPieDataSet.swift
@@ -18,6 +18,8 @@ import Realm.Dynamic
 
 open class RealmPieDataSet: RealmBaseDataSet, IPieChartDataSet
 {
+    public var useValueColorForLine: Bool = false
+    
     open override func initialize()
     {
         self.valueTextColor = NSUIColor.white

--- a/ChartsRealm/Classes/Data/RealmScatterDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmScatterDataSet.swift
@@ -47,10 +47,8 @@ open class RealmScatterDataSet: RealmLineScatterCandleRadarDataSet, IScatterChar
     }
     
     // MARK: NSCopying
-    
-    open override func copyWithZone(_ zone: NSZone?) -> AnyObject
-    {
-        let copy = super.copyWithZone(zone) as! RealmScatterDataSet
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = super.copy(with: zone) as! RealmScatterDataSet
         copy.scatterShapeSize = scatterShapeSize
         copy.scatterShapeHoleRadius = scatterShapeHoleRadius
         copy.scatterShapeHoleColor = scatterShapeHoleColor


### PR DESCRIPTION
BUILD FIXES FOR SWIFT 4.2

Toward issue #27 this PR fixes several build issues in Swift 4.2, which may only be present when using later (4.2-compatible) versions of several dependencies.

• IPieChartDataSet requires `useValueColorForLine` in data set.
• CopyWithZone has been renamed to copy(with: _)