### PR TITLE
Update RealmSwift version to 3.18

### DIFF
--- a/ChartsRealm.podspec
+++ b/ChartsRealm.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.source = { :git => "https://github.com/danielgindi/ChartsRealm.git", :tag => "v#{s.version}" }
   s.source_files  = "ChartsRealm/Classes/**/*.swift", "ChartsRealm/Supporting Files/RLMSupport.swift"
   s.dependency "Charts", "~> 3.3.0"
-  s.dependency "RealmSwift", "~> 3.15.0"
+  s.dependency "RealmSwift", "~> 3.18.0"
 end


### PR DESCRIPTION
There's an issue with iOS 13 and Xcode 11 which may cause the "Primary key property '' does not exist on object". All String properties of Realm classes with a default String value set are disregarded somehow. You can fix this by updating RealmSwift to the latest version (currently 3.18.0)